### PR TITLE
Fix grep command to exit with code 1 when cancelled with Ctrl+C

### DIFF
--- a/internal/cmd/grep.go
+++ b/internal/cmd/grep.go
@@ -60,6 +60,12 @@ var grepCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		// Ctrl+Cで終了した場合はexit code 1で終了
+		if model.cancelled {
+			os.Exit(1)
+		}
+
 		t := model.Selected()
 		dto := ticketDTO{
 			Key:              t.Key,
@@ -108,6 +114,7 @@ type grepModel struct {
 	width         int
 	height        int
 	configDir     string // 設定されたディレクトリを保持
+	cancelled     bool   // Ctrl+Cで終了したかどうか
 }
 
 type ticketItem struct {
@@ -179,6 +186,7 @@ func (m *grepModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c":
+			m.cancelled = true
 			return m, tea.Quit
 
 		case "enter":


### PR DESCRIPTION
## Summary
- Fix grep command to properly exit with code 1 when user cancels with Ctrl+C instead of exit code 0
- Add cancellation tracking to grepModel to distinguish between normal exit and user cancellation

## Test plan
- [ ] Run `tkt grep` command
- [ ] Press Ctrl+C to cancel
- [ ] Verify the command exits with code 1 (`echo $?` should show 1)
- [ ] Run `tkt grep` command  
- [ ] Select a ticket with Enter
- [ ] Verify the command exits with code 0 and outputs ticket JSON

🤖 Generated with [Claude Code](https://claude.ai/code)